### PR TITLE
Allow multiple providers in Planner DSL

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/lib/vapor/planner.ex
+++ b/lib/vapor/planner.ex
@@ -64,6 +64,19 @@ defmodule Vapor.Planner do
     end
   end
 
+  defmacro config(name, providers) when is_list(providers) do
+    quote do
+      @config_plan unquote(name)
+
+      defp __vapor_config__(unquote(name)) do
+        %Group{
+          name: unquote(name),
+          providers: unquote(providers)
+        }
+      end
+    end
+  end
+
   defmacro config(name, provider) do
     quote do
       @config_plan unquote(name)


### PR DESCRIPTION
I wanted to have multiple providers for a specific config sectionin a `Planner`:

```
  config :endpoint, [
    file("config.toml", [
      {:port, ["something", "port"]}
    ]),
    env([
      {:something_else, "SOMETHING_ELSE"}
    ])
  ]
```

I also added `.editorconfig` and `.gitattributes` to force LF newlines so that tests can be run on Windows machines.

Thoughts?